### PR TITLE
feat: add option to enable oauthtoken with LINEAR_IS_OAUTH_TOKEN=true

### DIFF
--- a/linear/utils.go
+++ b/linear/utils.go
@@ -21,7 +21,12 @@ type linearClient struct {
 }
 
 func (t *authedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Set("Authorization", "Bearer "+t.key)
+	isOauth:= os.Getenv("LINEAR_IS_OAUTH_TOKEN")=="true"
+	if isOauth{
+		req.Header.Set("Authorization", t.key)
+	}else{
+		req.Header.Set("Authorization", "Bearer "+t.key)
+	}
 	return t.wrapped.RoundTrip(req)
 }
 


### PR DESCRIPTION
This implements a very hacky fix for #27 which simply checks an environment variable to change the token type.

Note that I encounter a different issue, name that the library cannot parse a datetime of format `2024-03-05` because it expects the full `2024-03-05T16-08-30`  string