### PR TITLE
Add check for personal access key

### DIFF
--- a/linear/utils.go
+++ b/linear/utils.go
@@ -27,7 +27,7 @@ func (t *authedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if strings.HasPrefix(t.key, "lin_api") {
 		req.Header.Set("Authorization", t.key)
 	} else {
-		req.Header.Set("Authorization", "Bearer "+t.key)
+		req.Header.Set("Authorization", "Bearer " + t.key)
 	}
 	return t.wrapped.RoundTrip(req)
 }

--- a/linear/utils.go
+++ b/linear/utils.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/Khan/genqlient/graphql"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
@@ -21,7 +22,13 @@ type linearClient struct {
 }
 
 func (t *authedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Set("Authorization", "Bearer "+t.key)
+
+	// check if it is a personal access key
+	if strings.HasPrefix(t.key, "lin_api") {
+		req.Header.Set("Authorization", t.key)
+	} else {
+		req.Header.Set("Authorization", "Bearer "+t.key)
+	}
 	return t.wrapped.RoundTrip(req)
 }
 


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>

https://docs.gitguardian.com/secrets-detection/secrets-detection-engine/detectors/specifics/linear_api_key

```
#With personal access key

> select * from linear_user
+--------------------------------------+--------+-------+-------------+---------------------------------------------------------------->
| id                                   | active | admin | archived_at | avatar_url                                                     >
+--------------------------------------+--------+-------+-------------+---------------------------------------------------------------->
| 22da323e-2b90-4d65-a1a8-d7a8680fda76 | true   | true  | <null>      | https://public.linear.app/22da323e-2b90-4d65-a1a8-d7a8680fda76/>
+--------------------------------------+--------+-------+-------------+---------------------------------------------------------------

#with oauth

> select * from linear_user
+--------------------------------------+--------+-------+-------------+---------------------------------------------------------------->
| id                                   | active | admin | archived_at | avatar_url                                                     >
+--------------------------------------+--------+-------+-------------+---------------------------------------------------------------->
| 22da323e-2b90-4d65-a1a8-d7a8680fda76 | true   | true  | <null>      | https://public.linear.app/22da323e-2b90-4d65-a1a8-d7a8680fda76/>
+--------------------------------------+--------+-------+-------------+---------------------------------------------------------------->
```
</details>
